### PR TITLE
Update to 2.0.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,3 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    assignees:
-      - "CloudOn9"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This plugin is targeted for [PaperMc](https://papermc.io) users.
 This plugin should still work on [Spigot](https://spigotmc.org), but no guarantee is given.
 
 ##### Enjoy this plugin? Check out some of these links
-My [GitHub](https://github.com/cloudon9/)
+My [GitHub](https://github.com/cloudate9/)
 My [Discord](https://discord.gg/nPbakm9eEr)
 
 This project is licensed under the GNU-GPLv3. You can learn more about it [here](https://choosealicense.com/licenses/gpl-3.0/)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 import kr.entree.spigradle.kotlin.*
 
 plugins {
@@ -6,8 +7,8 @@ plugins {
     kotlin("jvm") version "1.6.10"
 }
 
-group = "io.github.cloudon9.instaminedeepslate"
-version = "2.0.0"
+group = "io.github.cloudate9.instaminedeepslate"
+version = "2.0.1"
 
 repositories {
     mavenCentral()
@@ -30,19 +31,24 @@ tasks {
         options.release.set(17)
     }
 
+    create<ConfigureShadowRelocation>("relocateShadowJar") {
+        target = shadowJar.get()
+        prefix = "${rootProject.group}.dependencies"
+    }
+
     shadowJar {
         archiveFileName.set(rootProject.name + "-" + rootProject.version + ".jar")
-
-        relocate("org.bstats", "io.github.cloudon9.instaminedeepslate.dependencies")
         minimize()
+
+        dependsOn(get("relocateShadowJar"))
     }
 }
 
 spigot {
-    authors = listOf("CloudOn9")
+    authors = listOf("Cloudate9")
     apiVersion = "1.18"
     description = "Makes mining deepslate with a Netherite pickaxe, eff 5 and haste II instant."
-    website = "https://cloudon9.github.io/"
+    website = "https://cloudate9.github.io/"
     commands {
         create("instaminedeepslate") {
             aliases = listOf("imd", "imds")

--- a/src/main/kotlin/io/github/cloudate9/instaminedeepslate/InstaMineDeepslate.kt
+++ b/src/main/kotlin/io/github/cloudate9/instaminedeepslate/InstaMineDeepslate.kt
@@ -1,8 +1,8 @@
-package io.github.cloudon9.instaminedeepslate
+package io.github.cloudate9.instaminedeepslate
 
-import io.github.cloudon9.instaminedeepslate.command.IMDCommand
-import io.github.cloudon9.instaminedeepslate.listener.MiningDeepslate
-import io.github.cloudon9.instaminedeepslate.listener.UpdateInformer
+import io.github.cloudate9.instaminedeepslate.command.IMDCommand
+import io.github.cloudate9.instaminedeepslate.listener.MiningDeepslate
+import io.github.cloudate9.instaminedeepslate.listener.UpdateInformer
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.TextColor
 import org.bstats.bukkit.Metrics
@@ -17,7 +17,7 @@ import java.util.*
 
 class InstaMineDeepslate : JavaPlugin() {
 
-    var updateFound = false; //Publically exposed
+    var updateFound = false //Publicly exposed
 
     override fun onEnable() {
 
@@ -41,7 +41,7 @@ class InstaMineDeepslate : JavaPlugin() {
                     val readGit = Scanner(
                         InputStreamReader(
                             URL(
-                                "https://raw.githubusercontent.com/CloudOn9/InstaMineDeepslate/master/build.gradle.kts"
+                                "https://raw.githubusercontent.com/Cloudate9/InstaMineDeepslate/master/build.gradle.kts"
                             ).openStream()
                         )
                     )

--- a/src/main/kotlin/io/github/cloudate9/instaminedeepslate/command/IMDCommand.kt
+++ b/src/main/kotlin/io/github/cloudate9/instaminedeepslate/command/IMDCommand.kt
@@ -1,4 +1,4 @@
-package io.github.cloudon9.instaminedeepslate.command
+package io.github.cloudate9.instaminedeepslate.command
 
 import net.kyori.adventure.text.minimessage.MiniMessage
 import org.bukkit.command.Command

--- a/src/main/kotlin/io/github/cloudate9/instaminedeepslate/listener/MiningDeepslate.kt
+++ b/src/main/kotlin/io/github/cloudate9/instaminedeepslate/listener/MiningDeepslate.kt
@@ -1,4 +1,4 @@
-package io.github.cloudon9.instaminedeepslate.listener
+package io.github.cloudate9.instaminedeepslate.listener
 
 import net.kyori.adventure.key.Key
 import net.kyori.adventure.sound.Sound

--- a/src/main/kotlin/io/github/cloudate9/instaminedeepslate/listener/UpdateInformer.kt
+++ b/src/main/kotlin/io/github/cloudate9/instaminedeepslate/listener/UpdateInformer.kt
@@ -1,6 +1,6 @@
-package io.github.cloudon9.instaminedeepslate.listener
+package io.github.cloudate9.instaminedeepslate.listener
 
-import io.github.cloudon9.instaminedeepslate.InstaMineDeepslate
+import io.github.cloudate9.instaminedeepslate.InstaMineDeepslate
 import net.kyori.adventure.text.event.ClickEvent
 import net.kyori.adventure.text.minimessage.MiniMessage
 import org.bukkit.configuration.file.FileConfiguration


### PR DESCRIPTION
- Rename everything from CloudOn9 to Cloudate9, to reflect new username. Helps to prevent update checker from potentially breaking by invalid repo.
- Reduce chance of causing issues when used with other plugins.