### PR TITLE
Version 2.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ This plugin should still work on [Spigot](https://spigotmc.org), but no guarante
 My [GitHub](https://github.com/cloudate9/)  
 My [Discord](https://discord.gg/nPbakm9eEr)
 
-This project is licensed under the GNU-GPLv3. You can learn more about it [here](https://choosealicense.com/licenses/gpl-3.0/)
+This project is licensed under the GNU-AGPLv3. You can learn more about it [here](https://choosealicense.com/licenses/agpl-3.0/)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This plugin only has one command - `/instaminedeepslate [enable/disable]`. To sa
 ##### Permissions
 ```yaml
 permissions:
-  instaminedeepslate.changespeed:
+  instaminedeepslate.configure:
     description: "Change if deepslate can be broken immediately, given the right conditions."
     default: op
   instaminedeepslate.eligible:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This plugin is targeted for [PaperMc](https://papermc.io) users.
 This plugin should still work on [Spigot](https://spigotmc.org), but no guarantee is given.
 
 ##### Enjoy this plugin? Check out some of these links
-My [GitHub](https://github.com/cloudate9/)
+My [GitHub](https://github.com/cloudate9/)  
 My [Discord](https://discord.gg/nPbakm9eEr)
 
 This project is licensed under the GNU-GPLv3. You can learn more about it [here](https://choosealicense.com/licenses/gpl-3.0/)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "io.github.cloudate9.instaminedeepslate"
-version = "2.0.3"
+version = "2.1.0"
 
 repositories {
     mavenCentral()
@@ -16,8 +16,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.18.1-R0.1-SNAPSHOT")
-    implementation("net.kyori:adventure-text-minimessage:4.1.0-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.18.2-R0.1-SNAPSHOT")
     implementation("org.bstats:bstats-bukkit:3.0.0")
 }
 
@@ -52,8 +51,8 @@ spigot {
         }
     }
     permissions {
-        create("instaminedeepslate.changespeed") {
-            description = "Change if deepslate can be broken immediately, given the right conditions."
+        create("instaminedeepslate.configure") {
+            description = "Configure IMD settings, such as if deepslate can be broken immediately, given the right conditions."
             defaults = "op"
         }
 

--- a/src/main/kotlin/io/github/cloudate9/instaminedeepslate/InstaMineDeepslate.kt
+++ b/src/main/kotlin/io/github/cloudate9/instaminedeepslate/InstaMineDeepslate.kt
@@ -18,12 +18,12 @@ import java.util.*
 
 class InstaMineDeepslate : JavaPlugin() {
 
-    val miniMessage = MiniMessage.get()
     var updateFound = false //Publicly exposed
 
     override fun onEnable() {
 
-        config.options().copyDefaults(true).copyHeader(true)
+        val miniMessage = MiniMessage.miniMessage()
+        config.options().copyDefaults(true).parseComments()
         saveConfig()
 
         val pluginManager = Bukkit.getPluginManager()

--- a/src/main/kotlin/io/github/cloudate9/instaminedeepslate/command/IMDCommand.kt
+++ b/src/main/kotlin/io/github/cloudate9/instaminedeepslate/command/IMDCommand.kt
@@ -18,9 +18,9 @@ class IMDCommand(
 
 
     override fun onCommand(sender: CommandSender, command: Command, alias: String, args: Array<out String>): Boolean {
-        if (sender is Player && !sender.hasPermission("instaminedeepslate.changespeed")) {
+        if (sender is Player && !sender.hasPermission("instaminedeepslate.configure")) {
             sender.sendMessage(
-                miniMessage.parse(
+                miniMessage.deserialize(
                     config.getString("message.miniMessage.noPermission")!!
                 )
             )
@@ -29,7 +29,7 @@ class IMDCommand(
 
         if (args.isEmpty()) {
             sender.sendMessage(
-                miniMessage.parse(
+                miniMessage.deserialize(
                     config.getString("message.miniMessage.invalidArguments")!!
                 )
             )
@@ -41,7 +41,7 @@ class IMDCommand(
             "disable", "off", "false" -> config["pluginActive"] = false
             else -> {
                 sender.sendMessage(
-                    miniMessage.parse(
+                    miniMessage.deserialize(
                         config.getString("message.miniMessage.invalidArguments")!!
                     )
                 )
@@ -49,10 +49,10 @@ class IMDCommand(
             }
         }
 
-        config.options().copyHeader(true)
+        config.options().parseComments()
         plugin.saveConfig()
         sender.sendMessage(
-            miniMessage.parse(
+            miniMessage.deserialize(
                 config.getString("message.miniMessage.success")!!
             )
         )
@@ -66,7 +66,7 @@ class IMDCommand(
         args: Array<out String>
     ): MutableList<String>? {
 
-        if (sender is Player && !sender.hasPermission("instaminedeepslate.changespeed")) return null
+        if (sender is Player && !sender.hasPermission("instaminedeepslate.configure")) return null
         if (args.size == 1)
             return StringUtil.copyPartialMatches(args[0], listOf("enable", "disable"), ArrayList())
 

--- a/src/main/kotlin/io/github/cloudate9/instaminedeepslate/listener/UpdateInformer.kt
+++ b/src/main/kotlin/io/github/cloudate9/instaminedeepslate/listener/UpdateInformer.kt
@@ -20,7 +20,7 @@ class UpdateInformer(
         if (config.getBoolean("updateCheck") && plugin.updateFound) {
             e.player.sendMessage(
                 miniMessage
-                    .parse(config.getString("message.miniMessage.updateFound")!!)
+                    .deserialize(config.getString("message.miniMessage.updateFound")!!)
                     .clickEvent(
                         ClickEvent.openUrl(
                             "https://www.curseforge.com/minecraft/bukkit-plugins/insta-mine-deepslate/"


### PR DESCRIPTION
Mainly changes the permission node instaminedeepslate.changespeed to instaminedeepslate.configure to better reflect what the permission does.

Now requires PaperMC 1.18.2 or better in order to function.